### PR TITLE
Fixed ISO filtering code to correctly load United Kingdom Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.noseids
 
 # Translations
 *.mo
@@ -40,3 +41,151 @@ nosetests.xml
 
 #mac
 .DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# static files generated from Django application using `collectstatic`
+media
+static
+
+
+# VSCode
+settings.json

--- a/pycovid/pycovid.py
+++ b/pycovid/pycovid.py
@@ -30,11 +30,18 @@ def getCovidCases(countries=None, provinces=None, start_date=None, end_date=None
             
 
             
+    iso_df = getIsoDf()
+               
+    df = pd.merge(df, iso_df, left_on="country_region", right_on='name')
+    
+    return df
+
+def getIsoDf():
     iso_df = pd.read_csv('https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/master/slim-3/slim-3.csv')
     iso_df = iso_df[['name', 'alpha-3']]
     iso_df.loc[iso_df.name=="United States of America", 'name'] = 'US'
     iso_df.loc[iso_df.name=="China", 'name'] = 'Mainland China'
-    iso_df.loc[iso_df.name=="United Kingdom", 'name'] = 'UK'
+    iso_df.loc[iso_df.name=="United Kingdom of Great Britain and Northern Ireland", 'name'] = 'United Kingdom'
     iso_df.loc[iso_df.name=="Russian Federation", 'name'] = 'Russia'
     iso_df.loc[iso_df.name=="Korea, Republic of", 'name'] = 'South Korea'
     iso_df.loc[iso_df.name=="Macao", 'name'] = 'Macau'
@@ -47,10 +54,7 @@ def getCovidCases(countries=None, provinces=None, start_date=None, end_date=None
     iso_df.loc[iso_df.name=="Moldova, Republic of", 'name'] = 'Moldova'
     iso_df.loc[iso_df.name=="Ireland", 'name'] = 'Republic of Ireland'
     iso_df.loc[iso_df.name=="Holy See", 'name'] = 'Vatican City'
-               
-    df = pd.merge(df, iso_df, left_on="country_region", right_on='name')
-    
-    return df
+    return iso_df
 
 def getCovidCasesWide(countries=None, start_date=None, end_date=None, casetype=['confirmed', 'death', 'recovered'], cumsum=False):
     df = pd.read_csv('https://raw.githubusercontent.com/RamiKrispin/coronavirus-csv/master/coronavirus_dataset.csv',
@@ -89,23 +93,7 @@ def getCovidCasesWide(countries=None, start_date=None, end_date=None, casetype=[
         
         
 
-    iso_df = pd.read_csv('https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/master/slim-3/slim-3.csv')
-    iso_df = iso_df[['name', 'alpha-3']]
-    iso_df.loc[iso_df.name=="United States of America", 'name'] = 'US'
-    iso_df.loc[iso_df.name=="China", 'name'] = 'China'
-    iso_df.loc[iso_df.name=="United Kingdom", 'name'] = 'UK'
-    iso_df.loc[iso_df.name=="Russian Federation", 'name'] = 'Russia'
-    iso_df.loc[iso_df.name=="Korea, Republic of", 'name'] = 'South Korea'
-    iso_df.loc[iso_df.name=="Macao", 'name'] = 'Macau'
-    iso_df.loc[iso_df.name=="Taiwan, Province of China", 'name'] = 'Taiwan'
-    iso_df.loc[iso_df.name=="Viet Nam", 'name'] = 'Vietnam'
-    iso_df.loc[iso_df.name=="Iran (Islamic Republic of)", 'name'] = 'Iran'
-    iso_df.loc[iso_df.name=="Czechia", 'name'] = 'Czech Republic'
-    iso_df.loc[iso_df.name=="Saint Barthélemy", 'name'] = 'Saint Barthelemy'
-    iso_df.loc[iso_df.name=="Palestine, State of", 'name'] = 'Palestine'
-    iso_df.loc[iso_df.name=="Moldova, Republic of", 'name'] = 'Moldova'
-    iso_df.loc[iso_df.name=="Ireland", 'name'] = 'Republic of Ireland'
-    iso_df.loc[iso_df.name=="Holy See", 'name'] = 'Vatican City'
+    iso_df = getIsoDf()
 
 
     
@@ -151,7 +139,7 @@ def plot_provinces(countries=None, provinces=None, start_date=None, end_date=Non
                     'Northwest Territory': 44598,  
                     'Yukon': 40369,  
                     'Nunavut': 38787
-                    };
+                    }
 
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,4 +1,14 @@
-# Sample Test passing with nose and pytest
+# 
 
 def test_pass():
     assert True, "dummy sample test"
+
+def test_get_covid_cases_uk():
+    from pycovid import pycovid
+    cases = pycovid.getCovidCases(countries=['United Kingdom'])
+    assert len(cases)
+
+def test_get_covid_cases_wide_uk():
+    from pycovid import pycovid
+    cases = pycovid.getCovidCasesWide(countries=['United Kingdom'])
+    assert len(cases)


### PR DESCRIPTION
The ISO data file called the United Kingdom "The United Kingdom of Great Britain and Northern Ireland". The original code replaced the "United Kingdom" with "UK" - but this failed to match any records in the data table - so all United Kingdom data was filtered out.

This change fixes that so United Kingdom data is now in the results data frame.

Tests added to check this and additional items added to .gitignore for common python files.